### PR TITLE
In order to format the harvest level name correctly for TCon materials,

### DIFF
--- a/src/main/java/iguanaman/iguanatweakstconstruct/override/HarvestLevelNameOverride.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/override/HarvestLevelNameOverride.java
@@ -72,6 +72,7 @@ public class HarvestLevelNameOverride implements IOverride {
 
             // if it's not a material, we try items
             if(!found) {
+                matName = prop.getString();
                 Item item = (Item)Item.itemRegistry.getObject(matName);
                 if(item != null) {
                     String name = (new ItemStack(item)).getDisplayName();


### PR DESCRIPTION
ITT does some string mashing on the harvest level names that come out of
the override cfg file (namely, they toLowerCase it).  However, item
registry names are case sensitive, so if the material search fails and ITT
then tries to find an item with the specified name, it will fail if the
modpack author wants to set the harvest level to an item name with capital
letters.  To fix this, I pull the raw string back into matName before the
item search.