### PR TITLE
Add ModRedstone itemstack check

### DIFF
--- a/src/main/java/iguanaman/iguanatweakstconstruct/replacing/ReplacementLogic.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/replacing/ReplacementLogic.java
@@ -340,6 +340,10 @@ public final class ReplacementLogic {
                 ModRedstone modRedstone = (ModRedstone)mod;
                 if(modRedstone instanceof ModXpAwareRedstone)
                     modRedstone = ((ModXpAwareRedstone)modRedstone).originalModifier;
+                
+                if(!modRedstone.stacks.contains(new ItemStack(Items.redstone)))
+                	continue;
+                
                 int[] keyPair = tags.getIntArray("Redstone");
                 // get amount of redstone applied
                 int rLvl = keyPair[0];


### PR DESCRIPTION
Fix an occasional bug where applyRedstone() would pick up redstone modifiers that don't use redstone as one of their itemstacks, and could crash the game later on. Fixes #151 and #136