### PR TITLE
Allow 0% base chance for mob head drops

### DIFF
--- a/src/main/java/iguanaman/iguanatweakstconstruct/reference/Config.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/reference/Config.java
@@ -181,7 +181,7 @@ public class Config {
         configfile.setCategoryComment(CATEGORY_Heads, "Mob Head Module: Adds additional Mob heads and drops");
 
         // drop behaviour
-        baseHeadDropChance      = configfile.getInt("baseDropChange", CATEGORY_Heads, 5, 1, 100, "Base percentage for a head to drop");
+        baseHeadDropChance      = configfile.getInt("baseDropChange", CATEGORY_Heads, 5, 0, 100, "Base percentage for a head to drop");
         beheadingHeadDropChance = configfile.getInt("beheadingDropChange", CATEGORY_Heads, 2, 1, 100, "Percentage added to base percentage per level of Beheading modifier");
 
 


### PR DESCRIPTION
Found something that bugged me slightly in that I can't disable mob head drops for tools without decapitation abilities outright.