### PR TITLE
Removed premature event.setCanceled

### DIFF
--- a/src/main/java/iguanaman/iguanatweakstconstruct/claybuckets/ClayBucketHandler.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/claybuckets/ClayBucketHandler.java
@@ -91,8 +91,6 @@ public class ClayBucketHandler {
 
                 return;
             }
-
-            event.setCanceled(true);
         }
     }
 }


### PR DESCRIPTION
This is an issue that disables support for 3rd party clay buckets, as the event.setCanceled would prevent further subscribers from getting called.